### PR TITLE
simplify staking on behalf of a user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.pem
 build/
 node_modules/
+*.bin
+*.swp


### PR DESCRIPTION
There is no longer a concept of staking from a different user than the
beneficiary.  _stake now takes a single address.  Since the hot wallet
will no longer be used to maintain the NMR for the 0-1m addresses,
transferDeposit now has a "to" address and a value.

fixes #21