### PR TITLE
Mint schedule

### DIFF
--- a/contracts/NumeraireBackend.sol
+++ b/contracts/NumeraireBackend.sol
@@ -3,10 +3,9 @@ pragma solidity ^0.4.8;
 // This is the contract that will be unchangeable once deployed.  It will call delegate functions in another contract to change state.  The delegate contract is upgradable.
 
 import "contracts/StoppableShareable.sol";
-import "contracts/Safe.sol";
 import "contracts/NumeraireShared.sol";
 
-contract NumeraireBackend is StoppableShareable, Safe, NumeraireShared {
+contract NumeraireBackend is StoppableShareable, NumeraireShared {
 
     address public delegateContract;
     bool contractUpgradable = true;
@@ -109,18 +108,6 @@ contract NumeraireBackend is StoppableShareable, Safe, NumeraireShared {
     function getStake(uint256 _tournamentID, uint256 _roundID, address _staker) constant returns (uint256[], uint256[], uint256[], uint256, uint256, bool, bool) {
         var stake = tournaments[_tournamentID].rounds[_roundID].stakes[_staker];
         return (stake.amounts, stake.confidences, stake.timestamps, stake.confidence, stake.amount, stake.successful, stake.resolved);
-    }
-
-    // Calculate allowable disbursement (dupe in delegate)
-    function getMintable() constant returns (uint256) {
-        if (!safeToSubtract(block.timestamp, deploy_time)) throw;
-        uint256 time_delta = (block.timestamp - deploy_time);
-        if (!safeToMultiply(weekly_disbursement, time_delta)) throw;
-        uint256 incremental_allowance = (weekly_disbursement * time_delta) / 1 weeks;
-        if (!safeToAdd(initial_disbursement, incremental_allowance)) throw;
-        uint256 total_allowance = initial_disbursement + incremental_allowance;
-        if (!safeToSubtract(total_allowance, total_minted)) throw;
-        return total_allowance - total_minted;
     }
 
     // ERC20: Send from a contract

--- a/contracts/NumeraireDelegate.sol
+++ b/contracts/NumeraireDelegate.sol
@@ -2,11 +2,10 @@ pragma solidity ^0.4.8;
 
 import "contracts/StoppableShareable.sol";
 import "contracts/DestructibleShareable.sol";
-import "contracts/Safe.sol";
 import "contracts/NumeraireShared.sol";
 
 // Whoever creates the contract has the power to stop it, this person can be changed via transferOwnership(_new_address)
-contract NumeraireDelegate is StoppableShareable, DestructibleShareable, Safe, NumeraireShared {
+contract NumeraireDelegate is StoppableShareable, DestructibleShareable, NumeraireShared {
 
     function NumeraireDelegate(address[] _owners, uint256 _num_required) StoppableShareable(_owners, _num_required) DestructibleShareable(_owners, _num_required) {
     }
@@ -33,19 +32,6 @@ contract NumeraireDelegate is StoppableShareable, DestructibleShareable, Safe, N
 
         return true;
     }
-
-    // Calculate allowable disbursement (dupe in backend)
-    function getMintable() constant returns (uint256) {
-        if (!safeToSubtract(block.timestamp, deploy_time)) throw;
-        uint256 time_delta = (block.timestamp - deploy_time);
-        if (!safeToMultiply(weekly_disbursement, time_delta)) throw;
-        uint256 incremental_allowance = (weekly_disbursement * time_delta) / 1 weeks;
-        if (!safeToAdd(initial_disbursement, incremental_allowance)) throw;
-        uint256 total_allowance = initial_disbursement + incremental_allowance;
-        if (!safeToSubtract(total_allowance, total_minted)) throw;
-        return total_allowance - total_minted;
-    }
-
 
     // Numerai calls this function to release staked tokens when the staked predictions were successful
     function releaseStake(address _staker, uint256 _etherValue, uint256 _tournamentID, uint256 _roundID, bool _successful) onlyOwner stopInEmergency returns (bool ok) {

--- a/contracts/NumeraireShared.sol
+++ b/contracts/NumeraireShared.sol
@@ -9,12 +9,12 @@ contract NumeraireShared {
 
     // Cap the total supply and the weekly supply
     uint256 public supply_cap = 21000000000000000000000000; // 21 million
-    uint256 public disbursement_cap = 96153846153846153846153;
+    uint256 public weekly_disbursement = 96153846153846153846153;
 
-    uint256 public disbursement_period = 1 weeks;
-    uint256 public disbursement_end_time;
+    uint256 public initial_disbursement;
+    uint256 public deploy_time;
 
-    uint256 public disbursement;
+    uint256 public total_minted;
     uint256 public total_supply;
 
     mapping (address => uint256) public balance_of;

--- a/contracts/NumeraireShared.sol
+++ b/contracts/NumeraireShared.sol
@@ -1,9 +1,10 @@
 pragma solidity ^0.4.8;
 
+import "contracts/Safe.sol";
 
 // Class variables used both in NumeraireBackend and NumeraireDelegate
 
-contract NumeraireShared {
+contract NumeraireShared is Safe {
 
     address public numerai = this;
 
@@ -55,4 +56,17 @@ contract NumeraireShared {
     event TournamentCreated(uint256 indexed tournamentID);
     event StakeDestroyed(uint256 indexed tournamentID, uint256 indexed roundID, address indexed stakerAddress);
     event StakeReleased(uint256 indexed tournamentID, uint256 indexed roundID, address indexed stakerAddress, uint256 etherReward);
+
+    // Calculate allowable disbursement
+    function getMintable() constant returns (uint256) {
+        if (!safeToSubtract(block.timestamp, deploy_time)) throw;
+        uint256 time_delta = (block.timestamp - deploy_time);
+        if (!safeToMultiply(weekly_disbursement, time_delta)) throw;
+        uint256 incremental_allowance = (weekly_disbursement * time_delta) / 1 weeks;
+        if (!safeToAdd(initial_disbursement, incremental_allowance)) throw;
+        uint256 total_allowance = initial_disbursement + incremental_allowance;
+        if (!safeToSubtract(total_allowance, total_minted)) throw;
+        return total_allowance - total_minted;
+    }
+
 }

--- a/test/numeraire.js
+++ b/test/numeraire.js
@@ -51,6 +51,7 @@ contract('Numeraire', function(accounts) {
         var etherAmount = new BigNumber('1000000000000000000')
         web3.eth.sendTransaction({from: accounts[0], to: multiSigAddresses[0], value: etherAmount, gasLimit: 21000, gasPrice: gasPrice})
         web3.eth.sendTransaction({from: accounts[5], to: multiSigAddresses[1], value: etherAmount, gasLimit: 21000, gasPrice: gasPrice})
+
         Numeraire.deployed().then(function(nmrInstance) {
             NumeraireDelegate.deployed().then(function(delegateInstance) {
                 nmrInstance.changeDelegate(delegateInstance.address, {from: multiSigAddresses[0]}).then(function() {
@@ -73,20 +74,21 @@ contract('Numeraire', function(accounts) {
         })
     })
 
-    it("should have set disbursement when deployed", function(done) {
+    it("should have set initial_disbursement when deployed", function(done) {
         Numeraire.deployed().then(function(nmrInstance) {
-            nmrInstance.disbursement.call().then(function(disbursement) {
+            nmrInstance.initial_disbursement.call().then(function(disbursement) {
                 assert.equal(true, disbursement.equals(initialDisbursement))
                 done()
             })
         })
     })
 
-    it("should not mint more than the disbursement", function(done) {
+    it("should not mint significantly more than the initial disbursement", function(done) {
         var prevBalance
         var nmr = Numeraire.deployed().then(function(instance) {
             prevBalance = web3.eth.getBalance(accounts[0])
-            instance.mint(initialDisbursement.add(1), {
+            // try to mint initalDisbursement + 1 NMR (should allow ~0.16 NMR/second)
+            instance.mint(initialDisbursement.add(new BigNumber(1000000000000000000)), {
                     from: accounts[0],
                     gasPrice: gasPrice,
                     gas: gasAmount
@@ -123,14 +125,14 @@ contract('Numeraire', function(accounts) {
         })
     })
 
-    it('should reduce disbursement when minting', function(done) {
+    it('should reduce mintable when minting', function(done) {
         var nmr = Numeraire.deployed().then(function(instance) {
-            return instance.disbursement.call().then(function(last_disbursement) {
-                return instance.mint(10000000000, {
+            return instance.getMintable.call().then(function(last_disbursement) {
+                return instance.mint(initialDisbursement, {
                     from: accounts[0]
                 }).then(function() {
-                    instance.disbursement.call().then(function(disbursement) {
-                        assert.equal(disbursement.toNumber(), last_disbursement.toNumber() - 10000000000)
+                    instance.getMintable.call().then(function(disbursement) {
+                        assert.equal(true, disbursement.equals(last_disbursement.sub(initialDisbursement)))
                         done()
                     })
                 })
@@ -138,9 +140,9 @@ contract('Numeraire', function(accounts) {
         })
     })
 
-    it("should reset disbursement once per week", function(done) {
+    it("should increase mintable 96153.846153846153846153 NMR per week", function(done) {
         var nmr = Numeraire.deployed().then(function(instance) {
-            return instance.disbursement.call().then(disbursement => {
+            return instance.getMintable.call().then(oldDisbursement => {
                 return instance.mint(500000, {
                     from: accounts[0]
                 }).then(() => {
@@ -148,8 +150,9 @@ contract('Numeraire', function(accounts) {
                         return instance.mint(20000000000, {
                             from: accounts[0]
                         }).then(() => {
-                            return instance.disbursement.call().then(disbursement => {
-                                assert.equal(96153846153846153846153 - 20000000000, disbursement.toNumber())
+                            return instance.getMintable.call().then(newDisbursement => {
+                                assert.equal(true, oldDisbursement.sub(500000).add(96153846153846100000000).
+                                    add(53846153).sub(20000000000).equals(newDisbursement))
                                 done()
                             })
                         })

--- a/test/numeraire.js
+++ b/test/numeraire.js
@@ -39,11 +39,27 @@ function ifUsingTestRPC() {
 var gasAmount = 3000000
 var gasPrice = 20000000000
 var initialDisbursement = new BigNumber(1500000000000000000000000)
+var nmr_per_week = new BigNumber(96153846153846100000000).add(53846153)
 
 var multiSigAddresses = ['0x54fd80d6ae7584d8e9a19fe1df43f04e5282cc43', '0xa6d135de4acf44f34e2e14a4ee619ce0a99d1e08']
 var Numeraire = artifacts.require("./NumeraireBackend.sol")
 var NumeraireDelegate = artifacts.require("./NumeraireDelegate.sol")
 var snapshotID = 0
+
+// either equal or two is a second after one.  it's okay if one second has
+// passed during the test
+function almost_equal(one, two) {
+  console.log("al: one:", one)
+  console.log("al: two:", two)
+  console.log("al: on+:", one.add(nmr_per_week.div(7 * 24 * 60 * 60)).ceil())
+  if (one.equals(two)) {
+    console.log("eq!")
+  }
+  if (two.equals(one.add(nmr_per_week.div(7 * 24 * 60 * 60)))) {
+    console.log("almost eq!")
+  }
+  return two.equals(one) || two.equals(one.add(nmr_per_week.div(7 * 24 * 60 * 60)).ceil())
+}
 
 contract('Numeraire', function(accounts) {
 
@@ -132,7 +148,7 @@ contract('Numeraire', function(accounts) {
                     from: accounts[0]
                 }).then(function() {
                     instance.getMintable.call().then(function(disbursement) {
-                        assert.equal(true, disbursement.equals(last_disbursement.sub(initialDisbursement)))
+                        assert.equal(true, almost_equal(last_disbursement.sub(initialDisbursement), disbursement))
                         done()
                     })
                 })
@@ -151,8 +167,7 @@ contract('Numeraire', function(accounts) {
                             from: accounts[0]
                         }).then(() => {
                             return instance.getMintable.call().then(newDisbursement => {
-                                assert.equal(true, oldDisbursement.sub(500000).add(96153846153846100000000).
-                                    add(53846153).sub(20000000000).equals(newDisbursement))
+                                assert.equal(true, almost_equal(oldDisbursement.sub(500000).add(nmr_per_week).sub(20000000000), newDisbursement))
                                 done()
                             })
                         })


### PR DESCRIPTION
Instead of requiring a manual mint once per week, we calculate the total
allowed of minted NMR up until now, and we permit minting up to that
point.

Some notes:
- in `getMintable()`, we multiply the number of seconds since contract deployment by `weekly_disbursement`, then divide by `1 weeks`.  This should work fine, but I could see an argument for simplifying by just storing a per-second disbursement value.  This would lose some precision, though.
- we don't have a "`safeToDivide`" function.  Division is always safe as long as the denominator is not zero, right?
- it is not possible to safely retrieve the return value of a `delegatecall` in solidity, so `getMintable()` is duplicated in the backend and delegate contracts.  I'm not sure I like that.
- I added an `almost_equal` function to the tests, which returns true if two numbers are equal, or exactly one-second-of-disbursement apart from each other.  This will work fine as long as the tests that test disbursement over time don't take more than a second to run, which they shouldn't.

fixes #13 
fixes #30