### PR TITLE
Spring cleaning

### DIFF
--- a/contracts/NumeraireBackend.sol
+++ b/contracts/NumeraireBackend.sol
@@ -78,7 +78,6 @@ contract NumeraireBackend is StoppableShareable, Safe, NumeraireShared {
         var tournament = tournaments[_tournamentID];
         if (tournament.creationTime != 0) throw; // Already created
         tournament.creationTime = block.timestamp;
-        tournament.numRounds = 0;
         TournamentCreated(_tournamentID);
         return true;
     }
@@ -90,25 +89,23 @@ contract NumeraireBackend is StoppableShareable, Safe, NumeraireShared {
         tournament.roundIDs.push(_roundID);
         round.creationTime = block.timestamp;
         round.resolutionTime = _resolutionTime;
-        round.numStakes = 0;
-        tournament.numRounds += 1;
         RoundCreated(_tournamentID, _roundID, round.resolutionTime);
         return true;
     }
 
-    function getTournament(uint256 _tournamentID) constant returns (uint256, uint256, uint256[]) {
+    function getTournament(uint256 _tournamentID) constant returns (uint256, uint256[]) {
         var tournament = tournaments[_tournamentID];
-        return (tournament.creationTime, tournament.numRounds, tournament.roundIDs);
+        return (tournament.creationTime, tournament.roundIDs);
     }
 
-    function getRound(uint256 _tournamentID, uint256 _roundID) constant returns (uint256, uint256, uint256, address[]) {
+    function getRound(uint256 _tournamentID, uint256 _roundID) constant returns (uint256, uint256, address[]) {
         var round = tournaments[_tournamentID].rounds[_roundID];
-        return (round.creationTime, round.resolutionTime, round.numStakes, round.stakeAddresses);
+        return (round.creationTime, round.resolutionTime, round.stakeAddresses);
     }
 
-    function getStake(uint256 _tournamentID, uint256 _roundID, address _staker) constant returns (uint256[], uint256[], uint256[], uint256, uint256, bool, bool) {
+    function getStake(uint256 _tournamentID, uint256 _roundID, address _staker) constant returns (uint256, uint256, bool, bool) {
         var stake = tournaments[_tournamentID].rounds[_roundID].stakes[_staker];
-        return (stake.amounts, stake.confidences, stake.timestamps, stake.confidence, stake.amount, stake.successful, stake.resolved);
+        return (stake.confidence, stake.amount, stake.successful, stake.resolved);
     }
 
     // Calculate allowable disbursement (dupe in delegate)

--- a/contracts/NumeraireDelegate.sol
+++ b/contracts/NumeraireDelegate.sol
@@ -122,7 +122,6 @@ contract NumeraireDelegate is StoppableShareable, DestructibleShareable, Safe, N
         if (_value <= 0) throw; // Can't stake zero NMR
 
         // Prevent overflows.
-        if (!safeToAdd(round.numStakes, 1)) throw;
         if (!safeToAdd(stake.amount, _value)) throw;
         if (!safeToSubtract(balance_of[_staker], _value)) throw;
 
@@ -137,12 +136,8 @@ contract NumeraireDelegate is StoppableShareable, DestructibleShareable, Safe, N
         }
 
         round.stakeAddresses.push(_staker);
-        round.numStakes += 1;
         stake.amount += _value;
         balance_of[_staker] -= _value;
-        stake.amounts.push(_value);
-        stake.confidences.push(stake.confidence);
-        stake.timestamps.push(block.timestamp);
 
         // Notify anyone listening.
         StakeCreated(_staker, stake.amount, _tournamentID, _roundID);
@@ -187,5 +182,4 @@ contract NumeraireDelegate is StoppableShareable, DestructibleShareable, Safe, N
 
         return true;
     }
-
 }

--- a/contracts/NumeraireShared.sol
+++ b/contracts/NumeraireShared.sol
@@ -23,7 +23,6 @@ contract NumeraireShared {
 
     struct Tournament {
         uint256 creationTime;
-        uint256 numRounds;
         uint256[] roundIDs;
         mapping (uint256 => Round) rounds;  // roundID
     } 
@@ -31,15 +30,11 @@ contract NumeraireShared {
     struct Round {
         uint256 creationTime;
         uint256 resolutionTime;
-        uint256 numStakes;
         address[] stakeAddresses;
         mapping (address => Stake) stakes;  // address of staker
     }
 
     struct Stake {
-        uint256[] amounts;
-        uint256[] confidences;
-        uint256[] timestamps;
         uint256 amount; // Once the stake is resolved, this becomes 0
         uint256 confidence;
         bool successful;


### PR DESCRIPTION
[Merge note: This is a descendant of #31.  If both are acceptable, then I recommend either (1) merge #31 with a fast-forward merge (always remember: the big green button is a succubus), then merge this, or (2) just merge this one, which will automatically close the other PR.]

This eliminates `numRounds`, `numStakes`, `amounts`, `confidences`, and `timestamps`.  See #32 and #35 for the rationale.